### PR TITLE
extend 'Not Connected' trigger 

### DIFF
--- a/template_drbd.xml
+++ b/template_drbd.xml
@@ -463,7 +463,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template DRBD:drbd.cstate[{#DRBDNAME}].str(Connected)}&lt;&gt;1</expression>
+                            <expression>{Template DRBD:drbd.cstate[{#DRBDNAME}].str(Connected)}&lt;&gt;1 and {Template DRBD:drbd.cstate[{#DRBDNAME}].str(VerifyT)}&lt;&gt;1 and {Template DRBD:drbd.cstate[{#DRBDNAME}].str(VerifyS)}&lt;&gt;1</expression>
                             <name>DRBD {#DRBDNAME} Device is not Connected on {HOST.NAME}</name>
                             <url/>
                             <status>0</status>


### PR DESCRIPTION
Hi, 
I added two more states, VerifyS(on slave) and VerifyT(on master) in order to not trigger  'Not Connected' trigger  when `/sbin/drbdadm verify all` is running.


```
cat /proc/drbd
version: 8.3.11 (api:88/proto:86-96)
srcversion: FB337CD104F0FDEF149C3E1
 0: cs:VerifyS ro:Secondary/Primary ds:UpToDate/UpToDate C r-----
    ns:0 nr:489136 dw:750467372 dr:858932993 al:15 bm:747 lo:0 pe:0 ua:0 ap:0 ep:1 wo:f oos:0
        [>...................] verified:  7.0% (852424/916344)Mfinish: 11:23:21 speed: 21,276 (19,000) want: 20,480 K/sec
```

Regards,
t0d0r